### PR TITLE
Update contract licenses to MIT

### DIFF
--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.9.0-5d98448",
+    "bls-wallet-clients": "0.9.0-405e23a",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/package.json
+++ b/aggregator-proxy/package.json
@@ -21,7 +21,7 @@
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
     "@types/node-fetch": "^2.6.1",
-    "bls-wallet-clients": "0.9.0-2a20bfe",
+    "bls-wallet-clients": "0.9.0-5d98448",
     "fp-ts": "^2.12.1",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^2.0.1",

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -569,16 +569,6 @@
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
   integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
-  dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
 
 "@ethersproject/units@5.6.0":
   version "5.6.0"
@@ -887,10 +877,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.9.0-5d98448:
-  version "0.9.0-5d98448"
-  resolved "https://registry.npmjs.org/bls-wallet-clients/-/bls-wallet-clients-0.9.0-5d98448.tgz#2387626724dc60b957e9e2c44c26f61fc64e5c47"
-  integrity sha512-MymcglLwEEwAbUUaz713G47bLgByzz4Hspb0PbqH5aJ0BRO7wgbflrK5Hk/xr06PPYXZ+WHbv3W1o9UWkLqTeA==
+bls-wallet-clients@0.9.0-405e23a:
+  version "0.9.0-405e23a"
+  resolved "https://registry.npmjs.org/bls-wallet-clients/-/bls-wallet-clients-0.9.0-405e23a.tgz#b66121f9ec0cb4e821965606ada203e6601b773d"
+  integrity sha512-cMm6pq35VU30veCAHt6ArSavlqzXu+olQg+dzUH28fvqSeQsfWz2qiuBekGxSWOCfn8gX1j/8jHEhrGxXS509Q==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator-proxy/yarn.lock
+++ b/aggregator-proxy/yarn.lock
@@ -569,16 +569,6 @@
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
   integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
-  dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
 
 "@ethersproject/units@5.6.0":
   version "5.6.0"
@@ -887,10 +877,10 @@ bech32@1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-bls-wallet-clients@0.9.0-2a20bfe:
-  version "0.9.0-2a20bfe"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.9.0-2a20bfe.tgz#2e39757a18df3ba78d816ae15f6b88000443a2a6"
-  integrity sha512-w4efcArPBEowrAkIdVYc2mOLlkN8E5O9eIqEhoo6IrRVrN21p/JVNdoot4N3o5MAKFbeaYfid/u9lL6p2DNdiw==
+bls-wallet-clients@0.9.0-5d98448:
+  version "0.9.0-5d98448"
+  resolved "https://registry.npmjs.org/bls-wallet-clients/-/bls-wallet-clients-0.9.0-5d98448.tgz#2387626724dc60b957e9e2c44c26f61fc64e5c47"
+  integrity sha512-MymcglLwEEwAbUUaz713G47bLgByzz4Hspb0PbqH5aJ0BRO7wgbflrK5Hk/xr06PPYXZ+WHbv3W1o9UWkLqTeA==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,7 +54,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.9.0-5d98448";
+} from "https://esm.sh/bls-wallet-clients@0.9.0-405e23a";
 
 export {
   Aggregator as AggregatorClient,
@@ -70,10 +70,10 @@ export {
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.9.0-5d98448";
+} from "https://esm.sh/bls-wallet-clients@0.9.0-405e23a";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.9.0-5d98448";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.9.0-405e23a";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/aggregator/deps.ts
+++ b/aggregator/deps.ts
@@ -54,7 +54,7 @@ export type {
   PublicKey,
   Signature,
   VerificationGateway,
-} from "https://esm.sh/bls-wallet-clients@0.9.0-2a20bfe";
+} from "https://esm.sh/bls-wallet-clients@0.9.0-5d98448";
 
 export {
   Aggregator as AggregatorClient,
@@ -70,10 +70,10 @@ export {
   getConfig,
   MockERC20Factory,
   VerificationGatewayFactory,
-} from "https://esm.sh/bls-wallet-clients@0.9.0-2a20bfe";
+} from "https://esm.sh/bls-wallet-clients@0.9.0-5d98448";
 
 // Workaround for esbuild's export-star bug
-import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.9.0-2a20bfe";
+import blsWalletClients from "https://esm.sh/bls-wallet-clients@0.9.0-5d98448";
 const { bundleFromDto, bundleToDto, initBlsWalletSigner } = blsWalletClients;
 export { bundleFromDto, bundleToDto, initBlsWalletSigner };
 

--- a/contracts/clients/package.json
+++ b/contracts/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bls-wallet-clients",
-  "version": "0.9.0-3251dec",
+  "version": "0.9.0",
   "description": "Client libraries for interacting with BLS Wallet components",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/contracts/contracts/AddressRegistry.sol
+++ b/contracts/contracts/AddressRegistry.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/AggregatorUtilities.sol
+++ b/contracts/contracts/AggregatorUtilities.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/BLSExpanderDelegator.sol
+++ b/contracts/contracts/BLSExpanderDelegator.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/BLSPublicKeyRegistry.sol
+++ b/contracts/contracts/BLSPublicKeyRegistry.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/BLSRegistration.sol
+++ b/contracts/contracts/BLSRegistration.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/BLSWallet.sol
+++ b/contracts/contracts/BLSWallet.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/ERC20Expander.sol
+++ b/contracts/contracts/ERC20Expander.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/ExpanderEntryPoint.sol
+++ b/contracts/contracts/ExpanderEntryPoint.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/FallbackExpander.sol
+++ b/contracts/contracts/FallbackExpander.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/VerificationGateway.sol
+++ b/contracts/contracts/VerificationGateway.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/interfaces/IExpander.sol
+++ b/contracts/contracts/interfaces/IExpander.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/interfaces/IWallet.sol
+++ b/contracts/contracts/interfaces/IWallet.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/lib/PseudoFloat.sol
+++ b/contracts/contracts/lib/PseudoFloat.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/lib/RegIndex.sol
+++ b/contracts/contracts/lib/RegIndex.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.15;
 
 import "./VLQ.sol";

--- a/contracts/contracts/lib/VLQ.sol
+++ b/contracts/contracts/lib/VLQ.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 pragma abicoder v2;
 

--- a/contracts/contracts/mock/MockWalletUpgraded.sol
+++ b/contracts/contracts/mock/MockWalletUpgraded.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4 <0.9.0;
 pragma abicoder v2;
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,7 +37,7 @@
     "assert-browserify": "^2.0.0",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.9.0-2a20bfe",
+    "bls-wallet-clients": "0.9.0-5d98448",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,7 +37,7 @@
     "assert-browserify": "^2.0.0",
     "async-mutex": "^0.3.2",
     "axios": "^0.27.2",
-    "bls-wallet-clients": "0.9.0-5d98448",
+    "bls-wallet-clients": "0.9.0-405e23a",
     "browser-passworder": "^2.0.3",
     "bs58check": "^2.1.2",
     "crypto-browserify": "^3.12.0",

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -1791,16 +1791,6 @@
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
   integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
-  dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
 
 "@ethersproject/transactions@^5.5.0", "@ethersproject/transactions@^5.6.2":
   version "5.6.2"
@@ -2898,10 +2888,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.9.0-5d98448:
-  version "0.9.0-5d98448"
-  resolved "https://registry.npmjs.org/bls-wallet-clients/-/bls-wallet-clients-0.9.0-5d98448.tgz#2387626724dc60b957e9e2c44c26f61fc64e5c47"
-  integrity sha512-MymcglLwEEwAbUUaz713G47bLgByzz4Hspb0PbqH5aJ0BRO7wgbflrK5Hk/xr06PPYXZ+WHbv3W1o9UWkLqTeA==
+bls-wallet-clients@0.9.0-405e23a:
+  version "0.9.0-405e23a"
+  resolved "https://registry.npmjs.org/bls-wallet-clients/-/bls-wallet-clients-0.9.0-405e23a.tgz#b66121f9ec0cb4e821965606ada203e6601b773d"
+  integrity sha512-cMm6pq35VU30veCAHt6ArSavlqzXu+olQg+dzUH28fvqSeQsfWz2qiuBekGxSWOCfn8gX1j/8jHEhrGxXS509Q==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"

--- a/extension/yarn.lock
+++ b/extension/yarn.lock
@@ -1791,16 +1791,6 @@
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
   integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
-  dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
 
 "@ethersproject/transactions@^5.5.0", "@ethersproject/transactions@^5.6.2":
   version "5.6.2"
@@ -2898,10 +2888,10 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bls-wallet-clients@0.9.0-2a20bfe:
-  version "0.9.0-2a20bfe"
-  resolved "https://registry.yarnpkg.com/bls-wallet-clients/-/bls-wallet-clients-0.9.0-2a20bfe.tgz#2e39757a18df3ba78d816ae15f6b88000443a2a6"
-  integrity sha512-w4efcArPBEowrAkIdVYc2mOLlkN8E5O9eIqEhoo6IrRVrN21p/JVNdoot4N3o5MAKFbeaYfid/u9lL6p2DNdiw==
+bls-wallet-clients@0.9.0-5d98448:
+  version "0.9.0-5d98448"
+  resolved "https://registry.npmjs.org/bls-wallet-clients/-/bls-wallet-clients-0.9.0-5d98448.tgz#2387626724dc60b957e9e2c44c26f61fc64e5c47"
+  integrity sha512-MymcglLwEEwAbUUaz713G47bLgByzz4Hspb0PbqH5aJ0BRO7wgbflrK5Hk/xr06PPYXZ+WHbv3W1o9UWkLqTeA==
   dependencies:
     "@thehubbleproject/bls" "^0.5.1"
     ethers "^5.7.2"


### PR DESCRIPTION
## What is this PR doing?
- Update `SPDX-License-Identifier` contract license metadata from `Unlicense` to `MIT` for consistency with rest of repo.
- No other non-MIT license references were discovered

## How can these changes be manually tested?
:eyes: , :judge: 

## Does this PR resolve or contribute to any issues?
Resolves https://github.com/getwax/bls-wallet/issues/607

## Checklist
~I have manually tested these changes~ No testing needed
- [x] Post a link to the PR in the group chat

## Guidelines
- If your PR is not ready, mark it as a draft
- The `resolve conversation` button is for reviewers, not authors
  - (But add a 'done' comment or similar)
